### PR TITLE
Fixes issues with models and properties

### DIFF
--- a/TeePhrase/Models/BlogIndex.cs
+++ b/TeePhrase/Models/BlogIndex.cs
@@ -2,7 +2,7 @@
 
 namespace TeePhrase.Models
 {
-    public class BlogIndex : ContentItem, IContentBase
+    public class BlogIndex : ContentBase
     {
     }
 }

--- a/TeePhrase/Models/ButtonLink.cs
+++ b/TeePhrase/Models/ButtonLink.cs
@@ -2,7 +2,8 @@
 
 namespace TeePhrase.Models
 {
-    public class Shop : ContentBase
+    public class ButtonLink : ContentBase
     {
+
     }
 }

--- a/TeePhrase/Models/Contact.cs
+++ b/TeePhrase/Models/Contact.cs
@@ -2,7 +2,7 @@
 
 namespace TeePhrase.Models
 {
-    public class Contact : ContentItem, IContentBase
+    public class Contact : ContentBase
     {
     }
 }

--- a/TeePhrase/Models/Design.cs
+++ b/TeePhrase/Models/Design.cs
@@ -3,7 +3,7 @@ using Umbraco.Headless.Client.Net.Models;
 
 namespace TeePhrase.Models
 {
-    public class Design : ContentItem, IContentBase
+    public class Design : ContentBase
     {
         public string Description { get; set; }
         public List<MediaItem> Photos { get; set; }

--- a/TeePhrase/Models/DesignCollection.cs
+++ b/TeePhrase/Models/DesignCollection.cs
@@ -2,7 +2,7 @@
 
 namespace TeePhrase.Models
 {
-    public class DesignCollection : ContentItem, IContentBase
+    public class DesignCollection : ContentBase
     {
     }
 }

--- a/TeePhrase/Models/GenericContent.cs
+++ b/TeePhrase/Models/GenericContent.cs
@@ -3,7 +3,7 @@ using Umbraco.Headless.Client.Net.Models;
 
 namespace TeePhrase.Models
 {
-    public class GenericContent: ContentItem, IContentBase
+    public class GenericContent : ContentBase
     {
         public UmbracoGrid BodyContent { get; set; }
     }

--- a/TeePhrase/Models/Home.cs
+++ b/TeePhrase/Models/Home.cs
@@ -3,7 +3,7 @@ using Umbraco.Headless.Client.Net.Models;
 
 namespace TeePhrase.Models
 {
-    public partial class Home : ContentItem, IContentBase
+    public partial class Home : ContentBase
     {
         public List<MediaItem> CarouselImages { get; set; }
         public string Lead { get; set; }

--- a/TeePhrase/Models/UniqueSellingPoint.cs
+++ b/TeePhrase/Models/UniqueSellingPoint.cs
@@ -2,9 +2,9 @@
 
 namespace TeePhrase.Models
 {
-    public class UniqueSellingPoint : ContentItem, IContentBase
+    public class UniqueSellingPoint : ContentBase
     {
-        public IContentBase ButtonLink { get; set; }
+        public ButtonLink ButtonLink { get; set; }
         public string ButtonTitle { get; set; }
         public string Description { get; set; }
         public string Icon { get; set; }

--- a/TeePhrase/TeePhrase.csproj
+++ b/TeePhrase/TeePhrase.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="UmbracoCms.Headless.Client" Version="0.9.7-CI-20190130-01" />
-    <PackageReference Include="UmbracoCms.Headless.Client.Web" Version="0.9.7-CI-20190130-01" />
+    <PackageReference Include="UmbracoCms.Headless.Client" Version="0.9.7-CI-20190227-01" />
+    <PackageReference Include="UmbracoCms.Headless.Client.Web" Version="0.9.7-CI-20190227-01" />
   </ItemGroup>
 
 </Project>

--- a/TeePhrase/Views/Shared/DisplayTemplates/Home.cshtml
+++ b/TeePhrase/Views/Shared/DisplayTemplates/Home.cshtml
@@ -35,7 +35,7 @@
             <i class="material-icons md-150">@usp.Icon</i>
             <h2>@usp.Title</h2>
             @Html.Raw(usp.Description)
-            @*<p><a class="btn btn-secondary" href="@usp.ButtonLink.Url" role="button">@usp.ButtonTitle</a></p>*@
+            <p><a class="btn btn-secondary" href="@usp.ButtonLink.Url" role="button">@usp.ButtonTitle</a></p>
         </div> //.col-lg-4 
     }
 </div><!-- /.row -->    

--- a/TeePhrase/Views/Shared/_PageHeader.cshtml
+++ b/TeePhrase/Views/Shared/_PageHeader.cshtml
@@ -1,5 +1,5 @@
 ﻿@inject PublishedContentService HeadlessService
-@model ContentItem
+@model ContentBase
 @{
     var ancestors = await HeadlessService.GetAncestors(Model.Id);
 }


### PR DESCRIPTION
This PR fixes #1 and #4 and it updates all the models to extend `ContentBase` instead of `ContentItem, IContentBase`. In the current version of the client library custom models should use `ContentBase`, as that is what the whole serialization and mapping setup is built up around.
`ContentItem` is only for the raw rest api object. The main difference lies in how the properties are constructed and nested.